### PR TITLE
Improve adaptive stepsize for PANOC and ZeroFPR

### DIFF
--- a/src/algorithms/forwardbackward.jl
+++ b/src/algorithms/forwardbackward.jl
@@ -69,7 +69,7 @@ Base.@kwdef mutable struct ForwardBackwardState{R,Tx,TAx}
     z_prev::Tx = copy(x)
 end
 
-f_model(state::ForwardBackwardState) = f_model(state.f_Ax, state.At_grad_f_Ax, state.res, state.gamma)
+f_model(state::ForwardBackwardState) = f_model(state.f_Ax, state.At_grad_f_Ax, state.res, 1 / state.gamma)
 
 function Base.iterate(iter::ForwardBackwardIteration{R}) where {R}
     x = copy(iter.x0)

--- a/src/utilities/fbetools.jl
+++ b/src/utilities/fbetools.jl
@@ -2,7 +2,7 @@ function f_model(
     f_x::R,
     grad_f_x::AbstractArray{C},
     res::AbstractArray{C},
-    gamma::R,
+    L::R,
 ) where {R<:Real,C<:RealOrComplex{R}}
-    return f_x - real(dot(grad_f_x, res)) + (0.5 / gamma) * norm(res)^2
+    return f_x - real(dot(grad_f_x, res)) + (L / 2) * norm(res)^2
 end


### PR DESCRIPTION
PANOC and ZeroFPR require a step size `gamma <= alpha/L` for `alpha < 1` and the smoothness constant `L` of the smooth term `f`. The backtracking procedure for `gamma` was not enforcing this: this fix updates the way the quadratic model for `f` is computed, and makes sure that `alpha/gamma` is used as diagonal Hessian in such quadratic model (and *not* `1/gamma`).

In fact in some edge cases, the former behavior may have led the line search for `tau` to fail, later in the algorithms iteration. This fix makes sure that a more conservative `gamma` is selected in those cases, reducing the chance of line search failure.