### PR TITLE
Fix typing issues in Nesterov and Broyden acceleration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.cov
-*.jl.*.cov
 *.jl.mem
+*.jl.*.cov
+*.jl.*.mem
 *.swp
 *.log
 *.aux

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ProximalAlgorithms"
 uuid = "140ffc9f-1907-541a-a177-7475e0a401e9"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/accel/broyden.jl
+++ b/src/accel/broyden.jl
@@ -2,7 +2,7 @@ using LinearAlgebra
 import Base: *
 import LinearAlgebra: mul!
 
-mutable struct BroydenOperator{R,TH}
+struct BroydenOperator{R,TH}
     H::TH
     theta_bar::R
 end
@@ -27,7 +27,7 @@ function update!(L::BroydenOperator{R,TH}, s, y) where {R,TH}
     else
         (1 - _sign(delta) * L.theta_bar) / (1 - delta)
     end
-    L.H += (s - Hy) / dot(s, (1 / theta - 1) * s + Hy) * sH
+    L.H .+= (s - Hy) / dot(s, (1 / theta - 1) * s + Hy) * sH
 end
 
 function reset!(L::BroydenOperator{R,TH}) where {R,TH}

--- a/src/accel/broyden.jl
+++ b/src/accel/broyden.jl
@@ -2,24 +2,23 @@ using LinearAlgebra
 import Base: *
 import LinearAlgebra: mul!
 
-mutable struct BroydenOperator{R<:Real,C<:Union{R,Complex{R}},T<:AbstractArray{C}}
-    H
+mutable struct BroydenOperator{R,TH}
+    H::TH
     theta_bar::R
-    function BroydenOperator{R,C,T}(x::T, H, theta_bar) where {R,C,T}
-        new(H, theta_bar)
-    end
 end
 
-BroydenOperator(
-    x::T;
-    H = I,
-    theta_bar = R(0.2),
-) where {R<:Real,C<:Union{R,Complex{R}},T<:AbstractArray{C}} =
-    BroydenOperator{R,C,T}(x, H, theta_bar)
+function BroydenOperator(::Type{T}, n::Integer, theta_bar=T(0.2)) where T
+    H = Matrix{T}(I, n, n)
+    BroydenOperator(H, theta_bar)
+end
+
+function BroydenOperator(x::AbstractVector{T}, theta_bar=T(0.2)) where T
+    BroydenOperator(T, length(x), theta_bar)
+end
 
 _sign(x::R) where {R} = x == 0 ? R(1) : sign(x)
 
-function update!(L::BroydenOperator{R,C,T}, s, y) where {R,C,T}
+function update!(L::BroydenOperator{R,TH}, s, y) where {R,TH}
     Hy = L.H * y
     sH = s' * L.H
     delta = dot(Hy, s) / norm(s)^2
@@ -31,9 +30,9 @@ function update!(L::BroydenOperator{R,C,T}, s, y) where {R,C,T}
     L.H += (s - Hy) / dot(s, (1 / theta - 1) * s + Hy) * sH
 end
 
-function reset!(L::BroydenOperator{R,C,T}) where {R,C,T}
-    L.H = I
-    L.theta_bar = R(0.2)
+function reset!(L::BroydenOperator{R,TH}) where {R,TH}
+    L.H .= 0
+    L.H[diagind(L.H)] .= 1
 end
 
 function (*)(L::BroydenOperator, v)
@@ -52,6 +51,6 @@ end
 
 acceleration_style(::Type{<:Broyden}) = QuasiNewtonStyle()
 
-function initialize(broyden::Broyden, x)
-    return BroydenOperator(x, theta_bar=broyden.theta_bar)
+function initialize(broyden::Broyden, x::AbstractVector{R}) where R
+    return BroydenOperator(x, broyden.theta_bar)
 end

--- a/src/accel/nesterov.jl
+++ b/src/accel/nesterov.jl
@@ -17,7 +17,7 @@ function Base.iterate(::FixedNesterovSequence{R}, t=R(1)) where R
 end
 
 Base.IteratorSize(::Type{<:FixedNesterovSequence}) = Base.IsInfinite()
-Base.IteratorEltype(::Type{FixedNesterovSequence{R}}) where R = R
+Base.eltype(::Type{FixedNesterovSequence{R}}) where R = R
 
 struct SimpleNesterovSequence{R} end
 
@@ -36,7 +36,7 @@ SimpleNesterovSequence(R) = SimpleNesterovSequence{R}()
 Base.iterate(::SimpleNesterovSequence{R}, k=1) where {R} = R(k - 1) / (k + 2), k + 1
 
 Base.IteratorSize(::Type{<:SimpleNesterovSequence}) = Base.IsInfinite()
-Base.IteratorEltype(::Type{SimpleNesterovSequence{R}}) where R = R
+Base.eltype(::Type{SimpleNesterovSequence{R}}) where R = R
 
 """
     ConstantNesterovSequence(m::R, stepsize::R)

--- a/test/accel/test_nesterov.jl
+++ b/test/accel/test_nesterov.jl
@@ -34,6 +34,7 @@ for sequence_type in [SimpleNesterovSequence, FixedNesterovSequence]
             @inferred initialize(NesterovExtrapolation(sequence_type), x)
 
             seq = sequence_type{R}()
+            @test eltype(seq) == R
 
             @inferred Iterators.peel(seq)
 


### PR DESCRIPTION
Fix the following:
* Wrong method for iteration protocol is implemented on Nesterov sequences to get the `eltype`
* `BroydenOperator` is unnecessarily mutable, and typed in an overly complex and incomplete manner

Bump bugfix version number.