### PR TITLE
Add PANOCpluc benchmarks

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,21 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 authors:
-  - family-names: Stella
-    given-names: Lorenzo
-title: ProximalAlgorithms.jl: Proximal algorithms for nonsmooth optimization in Julia
+- given-names: Lorenzo
+  family-names: Stella
+title: >-
+  ProximalAlgorithms.jl: Proximal algorithms for
+  nonsmooth optimization in Julia
 keywords:
-  - Proximal Algorithms
-  - Nonsmooth Optimization
-  - Julia
+  - proximal algorithms
+  - optimization
+  - julia
 type: software
-license: MIT Expat
-repository-code: https://github.com/JuliaFirstOrder/ProximalAlgorithms.jl
-message: If you use this software, please cite it using the metadata from this file.
+license: MIT
+repository-code: >-
+  https://github.com/JuliaFirstOrder/ProximalAlgorithms.jl
+message: >-
+If you use this software, please cite it using the
+metadata from this file.
 cff-version: 1.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,21 +1,21 @@
 # This CITATION.cff file was generated with cffinit.
 # Visit https://bit.ly/cffinit to generate yours today!
 
-authors:
-- given-names: Lorenzo
-  family-names: Stella
+cff-version: 1.2.0
 title: >-
   ProximalAlgorithms.jl: Proximal algorithms for
   nonsmooth optimization in Julia
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Lorenzo
+    family-names: Stella
+repository-code: >-
+  https://github.com/JuliaFirstOrder/ProximalAlgorithms.jl
 keywords:
   - proximal algorithms
   - optimization
   - julia
-type: software
 license: MIT
-repository-code: >-
-  https://github.com/JuliaFirstOrder/ProximalAlgorithms.jl
-message: >-
-If you use this software, please cite it using the
-metadata from this file.
-cff-version: 1.2.0

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -53,6 +53,13 @@ for (benchmark_name, file_name) in [
             g = NormL1($lam)
         end
 
+        SUITE[k]["PANOCplus"] = @benchmarkable solver(x0=x0, f=f, A=$A, g=g) setup=begin
+            solver = ProximalAlgorithms.PANOCplus(tol=1e-6)
+            x0 = zeros($T, size($A, 2))
+            f = Translate(SqrNormL2(), -$b)
+            g = NormL1($lam)
+        end
+
         SUITE[k]["DouglasRachford"] = @benchmarkable solver(x0=x0, f=f, g=g, gamma=$R(1)) setup=begin
             solver = ProximalAlgorithms.DouglasRachford(tol=1e-6)
             x0 = zeros($T, size($A, 2))


### PR DESCRIPTION
This PR adds the PANOCplus solver to the benchmarks.
The citation file has also been fixed (it could not be parsed).