### PR TITLE
Nonmonotone variant of linesearch methods

### DIFF
--- a/src/algorithms/drls.jl
+++ b/src/algorithms/drls.jl
@@ -147,8 +147,8 @@ update_direction_state!(iter::DRLSIteration, state::DRLSState) =
 
 function Base.iterate(iter::DRLSIteration{R,Tx,Tf}, state::DRLSState) where {R,Tx,Tf}
     # retrieve merit and set threshold
-    DRE_curr = state.merit
-    threshold = iter.dre_sign * DRE_curr - iter.c / iter.gamma * norm(state.res)^2
+    DRE_x = state.merit
+    threshold = iter.dre_sign * DRE_x - iter.c / iter.gamma * norm(state.res)^2
 
     set_next_direction!(iter, state)
 
@@ -163,13 +163,14 @@ function Base.iterate(iter::DRLSIteration{R,Tx,Tf}, state::DRLSState) where {R,T
     state.g_v = prox!(state.v, iter.g, state.w, iter.gamma)
     state.res .= state.u .- state.v
     state.xbar .= state.x .- iter.lambda * state.res
+    DRE_x = DRE(state)
 
     update_direction_state!(iter, state)
 
     a, b, c = R(0), R(0), R(0)
 
     for k = 1:iter.max_backtracks
-        if iter.dre_sign * DRE(state) <= threshold
+        if iter.dre_sign * DRE_x <= threshold
             break
         end
 
@@ -195,9 +196,10 @@ function Base.iterate(iter::DRLSIteration{R,Tx,Tf}, state::DRLSState) where {R,T
         state.g_v = prox!(state.v, iter.g, state.w, iter.gamma)
         state.res .= state.u .- state.v
         state.xbar .= state.x .- iter.lambda * state.res
+        DRE_x = DRE(state)
     end
     # update merit with averaging rule
-    state.merit = (1 - iter.monotonicity) * state.merit + iter.monotonicity * DRE(state)
+    state.merit = (1 - iter.monotonicity) * state.merit + iter.monotonicity * DRE_x
 
     return state, state
 end

--- a/src/algorithms/drls.jl
+++ b/src/algorithms/drls.jl
@@ -147,8 +147,7 @@ update_direction_state!(iter::DRLSIteration, state::DRLSState) =
 
 function Base.iterate(iter::DRLSIteration{R,Tx,Tf}, state::DRLSState) where {R,Tx,Tf}
     # retrieve merit and set threshold
-    DRE_x = state.merit
-    threshold = iter.dre_sign * DRE_x - iter.c / iter.gamma * norm(state.res)^2
+    threshold = iter.dre_sign * state.merit - iter.c / iter.gamma * norm(state.res)^2
 
     set_next_direction!(iter, state)
 

--- a/src/algorithms/panoc.jl
+++ b/src/algorithms/panoc.jl
@@ -193,10 +193,9 @@ function Base.iterate(iter::PANOCIteration{R,Tx,Tf}, state::PANOCState) where {R
     state.f_Ax = state.f_Ax_d
 
     # retrieve merit and set threshold
-    FBE_x = state.merit
     sigma = iter.beta * (0.5 / state.gamma) * (1 - iter.alpha)
-    tol = 10 * eps(R) * (1 + abs(FBE_x))
-    threshold = FBE_x - sigma * norm(state.res)^2 + tol
+    tol = 10 * eps(R) * (1 + abs(state.merit))
+    threshold = state.merit - sigma * norm(state.res)^2 + tol
 
     state.y .= state.x .- state.gamma .* state.At_grad_f_Ax
     state.g_z = prox!(state.z, iter.g, state.y, state.gamma)

--- a/src/algorithms/panoc.jl
+++ b/src/algorithms/panoc.jl
@@ -145,7 +145,7 @@ function Base.iterate(iter::PANOCIteration{R,Tx,Tf}, state::PANOCState) where {R
 
     if iter.adaptive == true
         gamma_prev = state.gamma
-        state.gamma, state.g_z, f_Az, f_Az_upp = backtrack_stepsize!(
+        state.gamma, state.g_z, f_Az, _ = backtrack_stepsize!(
             state.gamma,
             iter.f,
             iter.A,
@@ -201,10 +201,10 @@ function Base.iterate(iter::PANOCIteration{R,Tx,Tf}, state::PANOCState) where {R
     state.y .= state.x .- state.gamma .* state.At_grad_f_Ax
     state.g_z = prox!(state.z, iter.g, state.y, state.gamma)
     state.res .= state.x .- state.z
-    FBE_x_new = f_model(iter, state) + state.g_z
+    FBE_x = f_model(iter, state) + state.g_z
 
     for k = 1:iter.max_backtracks
-        if FBE_x_new <= threshold
+        if FBE_x <= threshold
             break
         end
 
@@ -248,12 +248,12 @@ function Base.iterate(iter::PANOCIteration{R,Tx,Tf}, state::PANOCState) where {R
         state.y .= state.x .- state.gamma .* state.At_grad_f_Ax
         state.g_z = prox!(state.z, iter.g, state.y, state.gamma)
         state.res .= state.x .- state.z
-        FBE_x_new = f_model(iter, state) + state.g_z
+        FBE_x = f_model(iter, state) + state.g_z
     end
 
     update_direction_state!(iter, state)
     # update merit with averaging rule
-    state.merit = (1 - iter.monotonicity) * state.merit + iter.monotonicity * FBE_x_new
+    state.merit = (1 - iter.monotonicity) * state.merit + iter.monotonicity * FBE_x
     return state, state
 end
 

--- a/src/algorithms/panocplus.jl
+++ b/src/algorithms/panocplus.jl
@@ -183,6 +183,7 @@ function Base.iterate(iter::PANOCplusIteration{R}, state::PANOCplusState) where 
 
     tau_backtracks = 0
     can_update_direction = true
+    FBE_x_new = R(0)
 
     while true
 
@@ -230,8 +231,6 @@ function Base.iterate(iter::PANOCplusIteration{R}, state::PANOCplusState) where 
 
         FBE_x_new = f_Az_upp + state.g_z
         if FBE_x_new <= threshold || tau_backtracks >= iter.max_backtracks
-            # update merit with averaging rule
-            state.merit = (1 - iter.monotonicity) * state.merit + iter.monotonicity * FBE_x_new
             break
         end
         state.tau = tau_backtracks >= iter.max_backtracks - 1 ? R(0) : state.tau / 2
@@ -240,6 +239,9 @@ function Base.iterate(iter::PANOCplusIteration{R}, state::PANOCplusState) where 
     end
 
     update_direction_state!(iter, state)
+
+    # update merit with averaging rule
+    state.merit = (1 - iter.monotonicity) * state.merit + iter.monotonicity * FBE_x_new
 
     return state, state
 

--- a/src/algorithms/panocplus.jl
+++ b/src/algorithms/panocplus.jl
@@ -175,10 +175,10 @@ function Base.iterate(iter::PANOCplusIteration{R}, state::PANOCplusState) where 
     state.res_prev .= state.res
 
     # retrieve merit and set threshold
-    FBE_x = state.merit
     sigma = iter.beta * (0.5 / state.gamma) * (1 - iter.alpha)
-    tol = 10 * eps(R) * (1 + abs(FBE_x))
-    threshold = FBE_x - sigma * norm(state.res)^2 + tol
+    tol = 10 * eps(R) * (1 + abs(state.merit))
+    threshold = state.merit - sigma * norm(state.res)^2 + tol
+    FBE_x = f_model(iter, state) + state.g_z
 
     tau_backtracks = 0
     can_update_direction = true

--- a/src/algorithms/zerofpr.jl
+++ b/src/algorithms/zerofpr.jl
@@ -193,10 +193,10 @@ function Base.iterate(iter::ZeroFPRIteration{R}, state::ZeroFPRState) where {R}
     mul!(state.Ad, iter.A, state.d)
 
     # retrieve merit and set threshold
-    FBE_x = state.merit
     sigma = iter.beta * (0.5 / state.gamma) * (1 - iter.alpha)
-    tol = 10 * eps(R) * (1 + abs(FBE_x))
-    threshold = FBE_x - sigma * norm(state.res)^2 + tol
+    tol = 10 * eps(R) * (1 + abs(state.merit))
+    threshold = state.merit - sigma * norm(state.res)^2 + tol
+    FBE_x = f_model(iter, state) + state.g_xbar
 
     for k = 1:iter.max_backtracks
         state.x .= state.xbar_prev .+ state.tau .* state.d

--- a/test/problems/test_lasso_small.jl
+++ b/test/problems/test_lasso_small.jl
@@ -241,6 +241,23 @@ using ProximalAlgorithms:
         @test x0 == x0_backup
     end
 
+    @testset "DouglasRachford line search ($acc) (nonmonotone)" for (acc, maxit) in [
+        (LBFGS(5), 25),
+        (Broyden(), 20),
+        (AndersonAcceleration(5), 12),
+        (NesterovExtrapolation(FixedNesterovSequence), 60),
+        (NesterovExtrapolation(SimpleNesterovSequence), 50),
+    ]
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.DRLS(tol=10 * TOL, directions=acc, monotonicity=R(0.5))
+        z, it = @inferred solver(x0=x0, f=fA_prox, g=g, Lf=Lf)
+        @test eltype(z) == T
+        @test norm(z - x_star, Inf) <= 10 * TOL
+        @test it < maxit
+        @test x0 == x0_backup
+    end
+
     @testset "AFBA" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)

--- a/test/problems/test_lasso_small.jl
+++ b/test/problems/test_lasso_small.jl
@@ -191,6 +191,17 @@ using ProximalAlgorithms:
 
     end
 
+    @testset "PANOC (fixed, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOC(tol = TOL, monotonicity=R(0.3))
+        x, it = @inferred solver(x0 = x0, f = f_autodiff, A = A, g = g, Lf = Lf)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= TOL
+        @test it < 20
+        @test x0 == x0_backup
+    end
+
     @testset "PANOC (adaptive step)" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)
@@ -199,6 +210,17 @@ using ProximalAlgorithms:
         @test eltype(x) == T
         @test norm(x - x_star, Inf) <= TOL
         @test it < 20
+        @test x0 == x0_backup
+    end
+
+    @testset "PANOC (adaptive, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOC(adaptive = true, tol = TOL, monotonicity=R(0.3))
+        x, it = @inferred solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= TOL
+        @test it < 35
         @test x0 == x0_backup
     end
 

--- a/test/problems/test_lasso_small.jl
+++ b/test/problems/test_lasso_small.jl
@@ -202,6 +202,17 @@ using ProximalAlgorithms:
         @test x0 == x0_backup
     end
 
+    @testset "PANOCplus (adaptive step, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOCplus(adaptive = true, tol = TOL, monotonicity=R(0.1))
+        x, it = @inferred solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= TOL
+        @test it < 40
+        @test x0 == x0_backup
+    end
+
     @testset "DouglasRachford" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)

--- a/test/problems/test_lasso_small.jl
+++ b/test/problems/test_lasso_small.jl
@@ -145,6 +145,17 @@ using ProximalAlgorithms:
         @test x0 == x0_backup
     end
 
+    @testset "ZeroFPR (fixed step, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.ZeroFPR(tol = TOL, monotonicity = R(0.2))
+        x, it = @inferred solver(x0 = x0, f = f_autodiff, A = A, g = g, Lf = Lf)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= TOL
+        @test it < 20
+        @test x0 == x0_backup
+    end
+
     @testset "ZeroFPR (adaptive step)" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)
@@ -153,6 +164,17 @@ using ProximalAlgorithms:
         @test eltype(x) == T
         @test norm(x - x_star, Inf) <= TOL
         @test it < 20
+        @test x0 == x0_backup
+    end
+
+    @testset "ZeroFPR (adaptive step, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.ZeroFPR(adaptive = true, tol = TOL, monotonicity = R(0.2))
+        x, it = @inferred solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= TOL
+        @test it < 30
         @test x0 == x0_backup
     end
 

--- a/test/problems/test_lasso_small_strongly_convex.jl
+++ b/test/problems/test_lasso_small_strongly_convex.jl
@@ -54,8 +54,8 @@ using ProximalAlgorithms
     x0_backup = copy(x0)
 
     @testset "SFISTA" begin
-        solver = ProximalAlgorithms.SFISTA(tol = TOL)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf = Lf, mf = mf)
+        solver = ProximalAlgorithms.SFISTA(tol=TOL)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf, mf=mf)
         @test eltype(y) == T
         @test norm(y - x_star) <= TOL
         @test it < 40
@@ -63,8 +63,8 @@ using ProximalAlgorithms
     end
 
     @testset "ForwardBackward" begin
-        solver = ProximalAlgorithms.ForwardBackward(tol = TOL)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf = Lf)
+        solver = ProximalAlgorithms.ForwardBackward(tol=TOL)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 110
@@ -72,8 +72,8 @@ using ProximalAlgorithms
     end
 
     @testset "ForwardBackward (adaptive step)" begin
-        solver = ProximalAlgorithms.ForwardBackward(tol = TOL, adaptive = true)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g)
+        solver = ProximalAlgorithms.ForwardBackward(tol=TOL, adaptive=true)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 300
@@ -82,11 +82,11 @@ using ProximalAlgorithms
 
     @testset "ForwardBackward (adaptive step, regret)" begin
         solver = ProximalAlgorithms.ForwardBackward(
-            tol = TOL,
-            adaptive = true,
-            increase_gamma = T(1.01),
+            tol=TOL,
+            adaptive=true,
+            increase_gamma=T(1.01),
         )
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 80
@@ -94,8 +94,8 @@ using ProximalAlgorithms
     end
 
     @testset "FastForwardBackward" begin
-        solver = ProximalAlgorithms.FastForwardBackward(tol = TOL)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf = Lf, mf = mf)
+        solver = ProximalAlgorithms.FastForwardBackward(tol=TOL)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf, mf=mf)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 35
@@ -103,8 +103,8 @@ using ProximalAlgorithms
     end
 
     @testset "FastForwardBackward (adaptive step)" begin
-        solver = ProximalAlgorithms.FastForwardBackward(tol = TOL, adaptive = true)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g)
+        solver = ProximalAlgorithms.FastForwardBackward(tol=TOL, adaptive=true)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 100
@@ -113,11 +113,11 @@ using ProximalAlgorithms
 
     @testset "FastForwardBackward (adaptive step, regret)" begin
         solver = ProximalAlgorithms.FastForwardBackward(
-            tol = TOL,
-            adaptive = true,
-            increase_gamma = T(1.01),
+            tol=TOL,
+            adaptive=true,
+            increase_gamma=T(1.01),
         )
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 100
@@ -125,14 +125,14 @@ using ProximalAlgorithms
     end
 
     @testset "FastForwardBackward (custom extrapolation)" begin
-        solver = ProximalAlgorithms.FastForwardBackward(tol = TOL)
+        solver = ProximalAlgorithms.FastForwardBackward(tol=TOL)
         y, it = solver(
-            x0 = x0,
-            f = fA_autodiff,
-            g = g,
-            gamma = 1 / Lf,
-            mf = mf,
-            extrapolation_sequence = ProximalAlgorithms.ConstantNesterovSequence(
+            x0=x0,
+            f=fA_autodiff,
+            g=g,
+            gamma=1 / Lf,
+            mf=mf,
+            extrapolation_sequence=ProximalAlgorithms.ConstantNesterovSequence(
                 mf,
                 1 / Lf,
             ),
@@ -144,8 +144,8 @@ using ProximalAlgorithms
     end
 
     @testset "DRLS" begin
-        solver = ProximalAlgorithms.DRLS(tol = TOL)
-        v, it = solver(x0 = x0, f = fA_prox, g = g, mf = mf)
+        solver = ProximalAlgorithms.DRLS(tol=TOL)
+        v, it = solver(x0=x0, f=fA_prox, g=g, mf=mf)
         @test eltype(v) == T
         @test norm(v - x_star, Inf) <= TOL
         @test it < 14
@@ -153,8 +153,8 @@ using ProximalAlgorithms
     end
 
     @testset "PANOC" begin
-        solver = ProximalAlgorithms.PANOC(tol = TOL)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf = Lf)
+        solver = ProximalAlgorithms.PANOC(tol=TOL)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 45
@@ -162,8 +162,17 @@ using ProximalAlgorithms
     end
 
     @testset "PANOCplus" begin
-        solver = ProximalAlgorithms.PANOCplus(tol = TOL)
-        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf = Lf)
+        solver = ProximalAlgorithms.PANOCplus(tol=TOL)
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)
+        @test eltype(y) == T
+        @test norm(y - x_star, Inf) <= TOL
+        @test it < 45
+        @test x0 == x0_backup
+    end
+
+    @testset "PANOCplus (nonmonotone)" begin
+        solver = ProximalAlgorithms.PANOCplus(tol=TOL, monotonicity=T(0.1))
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)
         @test eltype(y) == T
         @test norm(y - x_star, Inf) <= TOL
         @test it < 45

--- a/test/problems/test_lasso_small_strongly_convex.jl
+++ b/test/problems/test_lasso_small_strongly_convex.jl
@@ -152,6 +152,15 @@ using ProximalAlgorithms
         @test x0 == x0_backup
     end
 
+    @testset "DRLS (nonmonotone)" begin
+        solver = ProximalAlgorithms.DRLS(tol=TOL, monotonicity=T(0.1))
+        v, it = solver(x0=x0, f=fA_prox, g=g, mf=mf)
+        @test eltype(v) == T
+        @test norm(v - x_star, Inf) <= TOL
+        @test it < 14
+        @test x0 == x0_backup
+    end
+
     @testset "PANOC" begin
         solver = ProximalAlgorithms.PANOC(tol=TOL)
         y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)

--- a/test/problems/test_lasso_small_strongly_convex.jl
+++ b/test/problems/test_lasso_small_strongly_convex.jl
@@ -161,6 +161,24 @@ using ProximalAlgorithms
         @test x0 == x0_backup
     end
 
+    @testset "ZeroFPR (fixed, nonmonotone)" begin
+        solver = ProximalAlgorithms.ZeroFPR(tol = TOL, monotonicity = T(0.2))
+        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf=Lf)
+        @test eltype(y) == T
+        @test norm(y - x_star, Inf) <= TOL
+        @test it < 30
+        @test x0 == x0_backup
+    end
+
+    @testset "ZeroFPR (adaptive, nonmonotone)" begin
+        solver = ProximalAlgorithms.ZeroFPR(adaptive = true, tol = TOL, monotonicity = T(0.2))
+        y, it = solver(x0 = x0, f = fA_autodiff, g = g, Lf=Lf)
+        @test eltype(y) == T
+        @test norm(y - x_star, Inf) <= TOL
+        @test it < 30
+        @test x0 == x0_backup
+    end
+
     @testset "PANOC" begin
         solver = ProximalAlgorithms.PANOC(tol=TOL)
         y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)

--- a/test/problems/test_lasso_small_strongly_convex.jl
+++ b/test/problems/test_lasso_small_strongly_convex.jl
@@ -188,6 +188,15 @@ using ProximalAlgorithms
         @test x0 == x0_backup
     end
 
+    @testset "PANOC (nonmonotone)" begin
+        solver = ProximalAlgorithms.PANOC(tol=TOL, monotonicity=T(0.2))
+        y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)
+        @test eltype(y) == T
+        @test norm(y - x_star, Inf) <= TOL
+        @test it < 45
+        @test x0 == x0_backup
+    end
+
     @testset "PANOCplus" begin
         solver = ProximalAlgorithms.PANOCplus(tol=TOL)
         y, it = solver(x0=x0, f=fA_autodiff, g=g, Lf=Lf)

--- a/test/problems/test_nonconvex_qp.jl
+++ b/test/problems/test_nonconvex_qp.jl
@@ -45,6 +45,16 @@ using Test
         @test x0 == x0_backup
     end
 
+    @testset "PANOCplus (nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOCplus(tol = TOL, monotonicity=T(0.1))
+        x, it = solver(x0 = x0, f = f, g = g)
+        z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
+        @test norm(x - z, Inf) / gamma <= TOL
+        @test x0 == x0_backup
+    end
+
     @testset "ZeroFPR" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)
@@ -106,6 +116,16 @@ end
             x0 = zeros(T, n)
             x0_backup = copy(x0)
             solver = ProximalAlgorithms.PANOCplus(tol = TOL)
+            x, it = solver(x0 = x0, f = f, g = g)
+            z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
+            @test norm(x - z, Inf) / gamma <= TOL
+            @test x0 == x0_backup
+        end
+
+        @testset "PANOCplus (nonmonotone)" begin
+            x0 = zeros(T, n)
+            x0_backup = copy(x0)
+            solver = ProximalAlgorithms.PANOCplus(tol = TOL, monotonicity=T(0.1))
             x, it = solver(x0 = x0, f = f, g = g)
             z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
             @test norm(x - z, Inf) / gamma <= TOL

--- a/test/problems/test_nonconvex_qp.jl
+++ b/test/problems/test_nonconvex_qp.jl
@@ -35,6 +35,16 @@ using Test
         @test x0 == x0_backup
     end
 
+    @testset "PANOC (nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOC(tol = TOL, monotonicity=T(0.1))
+        x, it = solver(x0 = x0, f = f, g = g)
+        z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
+        @test norm(x - z, Inf) / gamma <= TOL
+        @test x0 == x0_backup
+    end
+
     @testset "PANOCplus" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)
@@ -106,6 +116,16 @@ end
             x0 = zeros(T, n)
             x0_backup = copy(x0)
             solver = ProximalAlgorithms.PANOC(tol = TOL)
+            x, it = solver(x0 = x0, f = f, g = g)
+            z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
+            @test norm(x - z, Inf) / gamma <= TOL
+            @test x0 == x0_backup
+        end
+
+        @testset "PANOC (nonmonotone)" begin
+            x0 = zeros(T, n)
+            x0_backup = copy(x0)
+            solver = ProximalAlgorithms.PANOC(tol = TOL, monotonicity=T(0.1))
             x, it = solver(x0 = x0, f = f, g = g)
             z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
             @test norm(x - z, Inf) / gamma <= TOL

--- a/test/problems/test_nonconvex_qp.jl
+++ b/test/problems/test_nonconvex_qp.jl
@@ -142,6 +142,16 @@ end
             @test x0 == x0_backup
         end
 
+        @testset "ZeroFPR (nonmonotone)" begin
+            x0 = zeros(T, n)
+            x0_backup = copy(x0)
+            solver = ProximalAlgorithms.ZeroFPR(tol = TOL, monotonicity=T(0.4))
+            x, it = solver(x0 = x0, f = f, g = g)
+            z = min.(upp, max.(low, x .- gamma .* (Q * x + q)))
+            @test norm(x - z, Inf) / gamma <= TOL
+            @test x0 == x0_backup
+        end
+
         @testset "LiLin" begin
             x0 = zeros(T, n)
             x0_backup = copy(x0)

--- a/test/problems/test_sparse_logistic_small.jl
+++ b/test/problems/test_sparse_logistic_small.jl
@@ -98,6 +98,17 @@ using LinearAlgebra
         @test x0 == x0_backup
     end
 
+    @testset "ZeroFPR (adaptive, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.ZeroFPR(adaptive = true, tol = TOL, monotonicity=R(0.5))
+        x, it = solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= 1e-4
+        @test it < 30
+        @test x0 == x0_backup
+    end
+
     @testset "PANOC (adaptive step)" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)

--- a/test/problems/test_sparse_logistic_small.jl
+++ b/test/problems/test_sparse_logistic_small.jl
@@ -120,4 +120,26 @@ using LinearAlgebra
         @test x0 == x0_backup
     end
 
+    @testset "PANOCplus (adaptive step, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOCplus(adaptive = true, tol = TOL, monotonicity=R(0.9))
+        x, it = solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= 1e-4
+        @test it < 50
+        @test x0 == x0_backup
+    end
+
+    @testset "PANOCplus (adaptive step, very nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOCplus(adaptive = true, tol = TOL, monotonicity=R(0.1))
+        x, it = solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= 1e-4
+        @test it < 110
+        @test x0 == x0_backup
+    end
+
 end

--- a/test/problems/test_sparse_logistic_small.jl
+++ b/test/problems/test_sparse_logistic_small.jl
@@ -120,6 +120,17 @@ using LinearAlgebra
         @test x0 == x0_backup
     end
 
+    @testset "PANOC (adaptive, nonmonotone)" begin
+        x0 = zeros(T, n)
+        x0_backup = copy(x0)
+        solver = ProximalAlgorithms.PANOC(adaptive = true, tol = TOL, monotonicity=R(0.5))
+        x, it = solver(x0 = x0, f = f_autodiff, A = A, g = g)
+        @test eltype(x) == T
+        @test norm(x - x_star, Inf) <= 1e-4
+        @test it < 50
+        @test x0 == x0_backup
+    end
+
     @testset "PANOCplus (adaptive step)" begin
         x0 = zeros(T, n)
         x0_backup = copy(x0)


### PR DESCRIPTION
This PR adds the possibility to run algorithms with a linesearch procedure in a nonmonotone variant. In particular,
- this feature addresses algorithms such as `PANOC`, `PANOCplus`, `ZeroFPR` and `DRLS`;
- a kwarg `monotonicity` is added to control the level of monotonicity required, with `0 < monotonicity <= 1`;
- the default `monotonicity = 1` coincides with the current implementation (monotone descent);
- a scalar value `merit` is included in the `state`, monitoring progress instead of objective or envelope values.