### PR TITLE
Allow to use 0.7.x version of DifferentiationInterface.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ ProximalCore = "dc4f5ac2-75d1-4f31-931e-60435d74994b"
 
 [compat]
 ADTypes = "1.5.3"
-DifferentiationInterface = "0.6.2"
+DifferentiationInterface = "0.6.2,0.7"
 LinearAlgebra = "1.2"
 Printf = "1.2"
 ProximalCore = "0.1"


### PR DESCRIPTION
The current compat of the package is

```txt
              julia                    1.6
   [47edcb42] ADTypes                  1.5.3
   [a0c0ee7d] DifferentiationInterface 0.6.2
   [37e2e46d] LinearAlgebra            1.2
   [de0858da] Printf                   1.2
   [dc4f5ac2] ProximalCore             0.1
```

The restriction on DifferentiationInterface.jl  precludes using version 0.7.x  that is required by other packages (like version  2.x of  Optimjl). I tested ProximalAlgorithms.jl, changing compat to 
```txt
              julia                    1.6
   [47edcb42] ADTypes                  1.5.3
   [a0c0ee7d] DifferentiationInterface 0.6.2,0.7
   [37e2e46d] LinearAlgebra            1.2
   [de0858da] Printf                   1.2
   [dc4f5ac2] ProximalCore             0.1
```
All tests passed. Hence, it seems possible to use 0.7.x version of DifferentiationInterface.jl.